### PR TITLE
Added user address, simplified to 1 address for test & mainnet

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,6 @@ APP_PORT=8080
 # Security (Generate strong random secrets!)
 JWT_SECRET=your_very_secret_key_here_32_bytes
 JWT_EXPIRATION_HOURS=72
-#SESSION_SECRET=your_session_secret_here_64_bytes # Needed if using session-based features
 
 # Database Configuration (PostgreSQL)
 DB_HOST=localhost
@@ -24,5 +23,4 @@ GOOGLE_REDIRECT_URL=http://localhost:8080/auth/callback # Must match the authori
 
 # X402 Payment Configuration
 X402_FACILITATOR_URL=https://x402.org/facilitator # Default public facilitator, or run your own
-X402_TESTNET_PAYMENT_ADDRESS=YOUR_TESTNET_WALLET_ADDRESS # e.g., Base Sepolia address
-X402_MAINNET_PAYMENT_ADDRESS=YOUR_MAINNET_WALLET_ADDRESS # e.g., Base address
+X402_PAYMENT_ADDRESS=YOUR_TESTNET_WALLET_ADDRESS # e.g., Base Sepolia address

--- a/config/config.go
+++ b/config/config.go
@@ -33,13 +33,6 @@ type Config struct {
 
 	// Auth configuration
 	Auth auth.Config `group:"auth" namespace:"auth"`
-
-	// X402 Config
-
-	// X402 Config
-	X402TestnetPaymentAddress string
-	X402MainnetPaymentAddress string
-	X402FacilitatorURL        string
 }
 
 var AppConfig *Config
@@ -118,8 +111,7 @@ func LoadConfig(logger *slog.Logger) *Config {
 	AppConfig.Store.SkipMigrations = skipMigrations
 
 	// Routes configuration
-	AppConfig.Routes.X402TestnetPaymentAddress = getEnvOrFatal("X402_TESTNET_PAYMENT_ADDRESS")
-	AppConfig.Routes.X402MainnetPaymentAddress = getEnvOrFatal("X402_MAINNET_PAYMENT_ADDRESS")
+	AppConfig.Routes.X402PaymentAddress = getEnvOrFatal("X402_PAYMENT_ADDRESS")
 	AppConfig.Routes.X402FacilitatorURL = getEnv("X402_FACILITATOR_URL", AppConfig.Routes.X402FacilitatorURL)
 
 	// Auth configuration
@@ -130,14 +122,6 @@ func LoadConfig(logger *slog.Logger) *Config {
 	AppConfig.Auth.GoogleClientID = getEnvOrFatal("GOOGLE_CLIENT_ID")
 	AppConfig.Auth.GoogleClientSecret = getEnvOrFatal("GOOGLE_CLIENT_SECRET")
 	AppConfig.Auth.GoogleRedirectURL = getEnvOrFatal("GOOGLE_REDIRECT_URL")
-
-	// Basic validation for essential x402 config
-	if AppConfig.Routes.X402TestnetPaymentAddress == "" {
-		log.Fatal("FATAL: X402_TESTNET_PAYMENT_ADDRESS environment variable is not set.")
-	}
-	if AppConfig.Routes.X402MainnetPaymentAddress == "" {
-		log.Fatal("FATAL: X402_MAINNET_PAYMENT_ADDRESS environment variable is not set.")
-	}
 
 	logger.Info("Configuration loaded.")
 

--- a/routes/config.go
+++ b/routes/config.go
@@ -3,15 +3,13 @@ package routes
 // DefaultConfig returns all default values for the Config struct.
 func DefaultConfig() *Config {
 	return &Config{
-		X402TestnetPaymentAddress: "",
-		X402MainnetPaymentAddress: "",
-		X402FacilitatorURL:        "https://x402.org/facilitator",
+		X402PaymentAddress: "",
+		X402FacilitatorURL: "https://x402.org/facilitator",
 	}
 }
 
 // Config holds the configuration for the routes package.
 type Config struct {
-	X402TestnetPaymentAddress string `long:"x402_testnet_payment_address" description:"Testnet payment address for X402"`
-	X402MainnetPaymentAddress string `long:"x402_mainnet_payment_address" description:"Mainnet payment address for X402"`
-	X402FacilitatorURL        string `long:"x402_facilitator_url" description:"URL for X402 facilitator"`
+	X402PaymentAddress string `long:"x402_payment_address" description:"Payment address for X402"`
+	X402FacilitatorURL string `long:"x402_facilitator_url" description:"URL for X402 facilitator"`
 }

--- a/store/sqlc/migrations/000002_user-address.down.sql
+++ b/store/sqlc/migrations/000002_user-address.down.sql
@@ -1,0 +1,5 @@
+-- Drop index on payment_address
+DROP INDEX IF EXISTS idx_users_payment_address;
+
+-- Remove payment_address column from users table
+ALTER TABLE users DROP COLUMN IF EXISTS payment_address;

--- a/store/sqlc/migrations/000002_user-address.up.sql
+++ b/store/sqlc/migrations/000002_user-address.up.sql
@@ -1,0 +1,5 @@
+-- Add payment_address column to users table
+ALTER TABLE users ADD COLUMN payment_address TEXT NOT NULL DEFAULT '';
+
+-- Create index on payment_address for faster lookups
+CREATE INDEX IF NOT EXISTS idx_users_payment_address ON users (payment_address);

--- a/store/sqlc/models.go
+++ b/store/sqlc/models.go
@@ -49,4 +49,5 @@ type User struct {
 	Proxy402Secret string
 	CreatedAt      time.Time
 	UpdatedAt      time.Time
+	PaymentAddress string
 }

--- a/store/sqlc/querier.go
+++ b/store/sqlc/querier.go
@@ -51,6 +51,8 @@ type Querier interface {
 	UpdatePaidRoute(ctx context.Context, arg UpdatePaidRouteParams) error
 	// UpdateUser updates a user record.
 	UpdateUser(ctx context.Context, arg UpdateUserParams) error
+	// UpdateUserPaymentAddress updates a user's payment address.
+	UpdateUserPaymentAddress(ctx context.Context, arg UpdateUserPaymentAddressParams) error
 	UpdateUserProxySecret(ctx context.Context, arg UpdateUserProxySecretParams) error
 }
 

--- a/store/sqlc/queries/users.sql
+++ b/store/sqlc/queries/users.sql
@@ -32,4 +32,11 @@ WHERE id = $1;
 UPDATE users SET
     proxy_402_secret = $2,
     updated_at = $3
+WHERE id = $1;
+
+-- name: UpdateUserPaymentAddress :exec
+-- UpdateUserPaymentAddress updates a user's payment address.
+UPDATE users SET
+    payment_address = $2,
+    updated_at = $3
 WHERE id = $1; 

--- a/store/sqlc/users.sql.go
+++ b/store/sqlc/users.sql.go
@@ -43,7 +43,7 @@ func (q *Queries) CreateUser(ctx context.Context, arg CreateUserParams) (int64, 
 }
 
 const getUserByEmail = `-- name: GetUserByEmail :one
-SELECT id, email, name, google_id, proxy_402_secret, created_at, updated_at FROM users
+SELECT id, email, name, google_id, proxy_402_secret, created_at, updated_at, payment_address FROM users
 WHERE email = $1
 `
 
@@ -59,12 +59,13 @@ func (q *Queries) GetUserByEmail(ctx context.Context, email string) (User, error
 		&i.Proxy402Secret,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.PaymentAddress,
 	)
 	return i, err
 }
 
 const getUserByGoogleID = `-- name: GetUserByGoogleID :one
-SELECT id, email, name, google_id, proxy_402_secret, created_at, updated_at FROM users
+SELECT id, email, name, google_id, proxy_402_secret, created_at, updated_at, payment_address FROM users
 WHERE google_id = $1
 `
 
@@ -80,12 +81,13 @@ func (q *Queries) GetUserByGoogleID(ctx context.Context, googleID string) (User,
 		&i.Proxy402Secret,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.PaymentAddress,
 	)
 	return i, err
 }
 
 const getUserByID = `-- name: GetUserByID :one
-SELECT id, email, name, google_id, proxy_402_secret, created_at, updated_at FROM users
+SELECT id, email, name, google_id, proxy_402_secret, created_at, updated_at, payment_address FROM users
 WHERE id = $1
 `
 
@@ -101,6 +103,7 @@ func (q *Queries) GetUserByID(ctx context.Context, id int64) (User, error) {
 		&i.Proxy402Secret,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.PaymentAddress,
 	)
 	return i, err
 }
@@ -121,6 +124,25 @@ type UpdateUserParams struct {
 // UpdateUser updates a user record.
 func (q *Queries) UpdateUser(ctx context.Context, arg UpdateUserParams) error {
 	_, err := q.db.Exec(ctx, updateUser, arg.ID, arg.Name, arg.UpdatedAt)
+	return err
+}
+
+const updateUserPaymentAddress = `-- name: UpdateUserPaymentAddress :exec
+UPDATE users SET
+    payment_address = $2,
+    updated_at = $3
+WHERE id = $1
+`
+
+type UpdateUserPaymentAddressParams struct {
+	ID             int64
+	PaymentAddress string
+	UpdatedAt      time.Time
+}
+
+// UpdateUserPaymentAddress updates a user's payment address.
+func (q *Queries) UpdateUserPaymentAddress(ctx context.Context, arg UpdateUserPaymentAddressParams) error {
+	_, err := q.db.Exec(ctx, updateUserPaymentAddress, arg.ID, arg.PaymentAddress, arg.UpdatedAt)
 	return err
 }
 

--- a/store/users.go
+++ b/store/users.go
@@ -59,6 +59,7 @@ func convertToUserModel(dbUser sqlc.User) *users.User {
 		Name:           dbUser.Name,
 		GoogleID:       dbUser.GoogleID,
 		Proxy402Secret: dbUser.Proxy402Secret,
+		PaymentAddress: dbUser.PaymentAddress,
 		CreatedAt:      dbUser.CreatedAt,
 		UpdatedAt:      dbUser.UpdatedAt,
 	}
@@ -73,6 +74,19 @@ func (s *Store) UpdateUserProxySecret(ctx context.Context, id uint, secret strin
 	})
 	if err != nil {
 		return fmt.Errorf("failed to update user proxy secret: %w", err)
+	}
+	return nil
+}
+
+// UpdateUserPaymentAddress updates a user's payment address.
+func (s *Store) UpdateUserPaymentAddress(ctx context.Context, id uint, address string) error {
+	err := s.queries.UpdateUserPaymentAddress(ctx, sqlc.UpdateUserPaymentAddressParams{
+		ID:             int64(id),
+		PaymentAddress: address,
+		UpdatedAt:      s.clock.Now(),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to update user payment address: %w", err)
 	}
 	return nil
 }

--- a/users/interface.go
+++ b/users/interface.go
@@ -23,4 +23,7 @@ type Store interface {
 
 	// UpdateUserProxySecret updates a user's proxy secret.
 	UpdateUserProxySecret(ctx context.Context, id uint, secret string) error
+
+	// UpdateUserPaymentAddress updates a user's payment address.
+	UpdateUserPaymentAddress(ctx context.Context, id uint, address string) error
 }

--- a/users/users.go
+++ b/users/users.go
@@ -7,10 +7,11 @@ import (
 // User represents a registered user in the system.
 type User struct {
 	ID             uint   `json:"-"`
-	Email          string `json:"email"`                                                 // Email is the primary identifier
-	Name           string `json:"name,omitempty"`                                        // User's name from Google
-	GoogleID       string `json:"-"`                                                     // Google user ID
-	Proxy402Secret string `gorm:"column:proxy_402_secret;uniqueIndex;not null" json:"-"` // Secret for forwarded request verification
+	Email          string `json:"email"`                     // Email is the primary identifier
+	Name           string `json:"name,omitempty"`            // User's name from Google
+	GoogleID       string `json:"-"`                         // Google user ID
+	Proxy402Secret string `json:"-"`                         // Secret for forwarded request verification
+	PaymentAddress string `json:"payment_address,omitempty"` // User's custom payment address
 
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`


### PR DESCRIPTION
How to create migrations:
1. `just migrate-create MIGRATION_NAME`
2. Fill in the up & down sql files
3. Fill any new queries required in sql files in `store/sqlc/queries` for example `store/sqlc/queries/users.sql`
4. Run `just sqlc`, this will convert the migrations & quries into auto-generated go files in `store/sqlc` e.g. `store/sqlc/users.sql.go`
5. Add the new store methods for example `store/users.go`
6. Update the interface of the module that will use that store, e.g. `users/interface.go`
