### PR TITLE
fix(price-input): auto-prefix leading ‘.’ with ‘0’ on blur

### DIFF
--- a/cmd/server/static/js/main.js
+++ b/cmd/server/static/js/main.js
@@ -171,15 +171,29 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 });
 
-// Initialize Lucide icons
+// Initialize Lucide icons and fix .01 price
+// Initialize Lucide icons, tooltips, and fix leading-dot price inputs
 document.addEventListener('DOMContentLoaded', function() {
+    // 1) Lucide
     if (window.lucide) {
         lucide.createIcons();
     }
     
-    // Enhanced tooltips for long URLs
+    // 2) Enhanced tooltips
     initializeEnhancedTooltips();
+
+    // 3) Auto-prefix leading “.x” with “0.x” on price input
+    const priceInput = document.getElementById('price-input');
+    if (priceInput) {
+        priceInput.addEventListener('blur', () => {
+            const v = priceInput.value.trim();
+            if (v.startsWith('.') && /^\.\d+$/.test(v)) {
+                priceInput.value = '0' + v;
+            }
+        });
+    }
 });
+
 
 // Function to initialize enhanced tooltips for long URLs
 function initializeEnhancedTooltips() {


### PR DESCRIPTION
My first time adding a URL following the getting started guide, I found myself getting an input error since I tried .01 instead of 0.01 - this is a simpler fix than trying to adjust the json, string and uint64 formatting and division that is already working. It simply adds the 0 before the decimal after moving focus away.
Thanks!

https://github.com/user-attachments/assets/2abe3802-fa16-46fc-92b7-b53cecb19342

