### PR TITLE
Fix README payment variable name

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,7 +23,7 @@ GOOGLE_REDIRECT_URL=http://localhost:8080/auth/callback # Must match the authori
 
 # X402 Payment Configuration
 X402_FACILITATOR_URL=https://x402.org/facilitator # Default public facilitator, or run your own
-X402_PAYMENT_ADDRESS=YOUR_TESTNET_WALLET_ADDRESS # e.g., Base address
+X402_PAYMENT_ADDRESS=YOUR_WALLET_ADDRESS # works for Base Sepolia & Base Mainnet
 # CDP api keys (access via [Coinbase Developer Platform](https://docs.cdp.coinbase.com/))
 CDP_API_KEY_ID=
 CDP_API_KEY_SECRET=

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ docker compose up
 ```
 
 Important .env variables:
-- `X402_TESTNET_PAYMENT_ADDRESS` & `X402_MAINNET_PAYMENT_ADDRESS`: Your Base addresses for receiving payments
+- `X402_PAYMENT_ADDRESS`: Your Base wallet address for receiving payments (works for Base Sepolia & Base Mainnet)
 - `GOOGLE_CLIENT_ID` & `GOOGLE_CLIENT_SECRET`: For auth (obtain from [Google Cloud Console](https://console.cloud.google.com/apis/credentials))
 
 ### Creating Monetized Routes


### PR DESCRIPTION
## Summary
- update README to reference `X402_PAYMENT_ADDRESS` instead of old testnet/mainnet variables
- note that the same address works for Base Sepolia & Base Mainnet

## Testing
- `go test ./...` *(fails: proxyconnect tcp: no route to host)*