### PR TITLE
Add x402 debug web page

### DIFF
--- a/cmd/server/static/js/debug.js
+++ b/cmd/server/static/js/debug.js
@@ -1,0 +1,24 @@
+document.addEventListener('DOMContentLoaded', function () {
+  const form = document.getElementById('debug-form');
+  const output = document.getElementById('response-output');
+  form.addEventListener('submit', async function (e) {
+    e.preventDefault();
+    const url = document.getElementById('target-url').value;
+    const method = document.getElementById('method-select').value;
+    const payment = document.getElementById('payment-header').value.trim();
+    output.textContent = 'Loading...';
+    try {
+      const headers = {};
+      if (payment) headers['X-Payment'] = payment;
+      const res = await fetch(url, { method: method, headers: headers });
+      const text = await res.text();
+      try {
+        output.textContent = JSON.stringify(JSON.parse(text), null, 2);
+      } catch {
+        output.textContent = text;
+      }
+    } catch (err) {
+      output.textContent = 'Request failed: ' + err;
+    }
+  });
+});

--- a/cmd/server/templates/debug.html
+++ b/cmd/server/templates/debug.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Proxy402 Debugger</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="icon" href="/static/img/favicon.svg" type="image/svg+xml">
+    <link rel="stylesheet" href="/static/css/style.css">
+    <script src="https://unpkg.com/lucide@latest"></script>
+    <script src="/static/js/debug.js" defer></script>
+</head>
+<body>
+    <nav class="navbar">
+        <div class="navbar-brand">
+            <a href="/" class="logo">Proxy402</a>
+            <span class="navbar-tagline">
+                by
+                <a href="https://fewsats.com" target="_blank" rel="noopener noreferrer">
+                    <img src="/static/img/logo.svg" alt="Logo" class="navbar-logo-inline">
+                </a>
+            </span>
+        </div>
+    </nav>
+
+    <div class="main-container">
+        <h1 class="page-header">Debug x402 Endpoint</h1>
+        <form id="debug-form" class="create-link-form open">
+            <div class="form-group">
+                <input type="url" id="target-url" placeholder="https://example.com/resource" required style="flex:1">
+                <select id="method-select">
+                    <option value="GET">GET</option>
+                    <option value="POST">POST</option>
+                </select>
+                <input type="text" id="payment-header" placeholder="X-Payment header (optional)" style="flex:1">
+                <button type="submit" class="btn" id="send-btn">Send</button>
+            </div>
+        </form>
+        <pre id="response-output" style="margin-top:1rem; white-space:pre-wrap;"></pre>
+    </div>
+    <script>
+        document.addEventListener("DOMContentLoaded", function() { lucide.createIcons(); });
+    </script>
+</body>
+</html>

--- a/ui/handler.go
+++ b/ui/handler.go
@@ -104,6 +104,9 @@ func (h *UIHandler) SetupRoutes(router *gin.Engine) {
 	// Public landing page for non-authenticated users
 	router.GET("/", h.handleLandingPage)
 
+	// Debugger page for testing endpoints
+	router.GET("/debug", h.handleDebug)
+
 	// Dashboard for authenticated users
 	router.GET("/dashboard", auth.AuthMiddleware(h.authService), h.handleDashboard)
 
@@ -134,6 +137,11 @@ func (h *UIHandler) handleLandingPage(gCtx *gin.Context) {
 		"baseURL":           h.getBaseURL(gCtx),
 		"GoogleAnalyticsID": h.config.GoogleAnalyticsID,
 	})
+}
+
+// handleDebug renders the debug page used to test x402 endpoints
+func (h *UIHandler) handleDebug(gCtx *gin.Context) {
+	gCtx.HTML(http.StatusOK, "debug.html", gin.H{})
 }
 
 // handleDashboard handles the main dashboard page for authenticated users


### PR DESCRIPTION
## Summary
- add a `debug.html` page and JS helper
- update UI handler to serve `/debug`

## Testing
- `go build ./...` *(fails: proxyconnect tcp: dial tcp 172.24.0.3:8080: connect: no route to host)*